### PR TITLE
Add sample ETL test with pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Easy way to learn Automation in all phases of application Web,API and Java.
         implementation "io.rest-assured:xml-path:${restAssuredVersion}"
         implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
         implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+
+## Running tests
+
+To execute the sample ETL test, install the required Python dependencies and run:
+
+```bash
+pytest tests/test_sample_etl.py
+```
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_sample_etl.py
+++ b/tests/test_sample_etl.py
@@ -1,0 +1,25 @@
+import io
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_csv():
+    return "id,name\n1,Alice\n2,Bob\n"
+
+
+@pytest.fixture
+def output_store():
+    store = {}
+    yield store
+    store.clear()
+
+
+def test_sample_etl(sample_csv, output_store):
+    df = pd.read_csv(io.StringIO(sample_csv), dtype={"id": str})
+    df["id"] = df["id"].astype(int)
+    output_store["data"] = df
+
+    assert df["id"].dtype == "int64"
+    assert output_store["data"].shape == (2, 2)
+    assert list(output_store["data"]["name"]) == ["Alice", "Bob"]


### PR DESCRIPTION
## Summary
- add pytest.ini with tests directory
- create sample ETL test using pandas fixtures
- document running tests in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0dcbb8f18832f8da361afb6caf2bc