### PR TITLE
Add sample model and hallucination regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ Easy way to learn Automation in all phases of application Web,API and Java.
         implementation "io.rest-assured:xml-path:${restAssuredVersion}"
         implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
         implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+
+## Running tests
+
+To execute the sample ETL test, install the required Python dependencies and run:
+
+```bash
+pytest tests/test_sample_etl.py
+```
+
+To run the regression suite, including hallucination checks maintained by @smike and @a11y, use:
+
+```bash
+pytest -m regression
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+markers =
+    regression: regression tests
+    smike: tests overseen by @smike
+    a11y: accessibility-related tests for @a11y

--- a/sample_model.py
+++ b/sample_model.py
@@ -1,0 +1,34 @@
+"""Simple model sampler for demonstration purposes.
+
+This module contains a small function that returns factual answers for
+predefined prompts. If the prompt is unknown, a ValueError is raised to
+simulate hallucination detection.
+"""
+from typing import Dict
+
+
+def sample_model(prompt: str) -> str:
+    """Return a factual answer for known prompts.
+
+    Parameters
+    ----------
+    prompt: str
+        The question or prompt to the model.
+
+    Returns
+    -------
+    str
+        The model's answer.
+
+    Raises
+    ------
+    ValueError
+        If the prompt is unknown, indicating a hallucination.
+    """
+    knowledge: Dict[str, str] = {
+        "What is the capital of France?": "Paris",
+        "What is 2 + 2?": "4",
+    }
+    if prompt in knowledge:
+        return knowledge[prompt]
+    raise ValueError("Model hallucinated: unknown prompt")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path for imports
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -1,0 +1,19 @@
+import pytest
+from sample_model import sample_model
+
+
+@pytest.mark.regression
+@pytest.mark.smike
+@pytest.mark.a11y
+def test_known_prompt_no_hallucination():
+    """Model returns expected answer for a known prompt."""
+    assert sample_model("What is the capital of France?") == "Paris"
+
+
+@pytest.mark.regression
+@pytest.mark.smike
+@pytest.mark.a11y
+def test_unknown_prompt_raises_error():
+    """Model raises ValueError when encountering an unknown prompt."""
+    with pytest.raises(ValueError):
+        sample_model("Who is the president of Mars?")

--- a/tests/test_sample_etl.py
+++ b/tests/test_sample_etl.py
@@ -1,0 +1,25 @@
+import io
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_csv():
+    return "id,name\n1,Alice\n2,Bob\n"
+
+
+@pytest.fixture
+def output_store():
+    store = {}
+    yield store
+    store.clear()
+
+
+def test_sample_etl(sample_csv, output_store):
+    df = pd.read_csv(io.StringIO(sample_csv), dtype={"id": str})
+    df["id"] = df["id"].astype(int)
+    output_store["data"] = df
+
+    assert df["id"].dtype == "int64"
+    assert output_store["data"].shape == (2, 2)
+    assert list(output_store["data"]["name"]) == ["Alice", "Bob"]


### PR DESCRIPTION
## Summary
- create simple knowledge-based `sample_model` for prompt answers
- add hallucination tests marked for @smike and @a11y in regression suite
- document regression suite usage and configure pytest markers

## Testing
- `pytest -q`
- `pytest -m regression -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0dcbb8f18832f8da361afb6caf2bc